### PR TITLE
Provide a way to create a shared ServerKey

### DIFF
--- a/src/Servant/Server/Experimental/Auth/Cookie.hs
+++ b/src/Servant/Server/Experimental/Auth/Cookie.hs
@@ -36,6 +36,7 @@ module Servant.Server.Experimental.Auth.Cookie
 
   , ServerKey
   , mkServerKey
+  , mkServerKeyFromBytes
   , getServerKey
 
   , AuthCookieSettings (..)
@@ -176,6 +177,16 @@ mkServerKey :: MonadIO m
   -> m ServerKey       -- ^ New 'ServerKey'
 mkServerKey size maxAge =
   ServerKey size maxAge `liftM` liftIO (mkServerKeyState size maxAge >>= newIORef)
+
+-- | Constructor for 'ServerKey' value using predefined key.
+mkServerKeyFromBytes :: MonadIO m
+  => ByteString     -- ^ Predefined key
+  -> m ServerKey    -- ^ New 'ServerKey'
+mkServerKeyFromBytes bytes =
+  ServerKey (BS.length bytes) Nothing `liftM` liftIO (newIORef (bytes, timeOrigin)) 
+  where
+    -- we don't care about the time as the key never expires
+    timeOrigin = UTCTime (toEnum 0) 0
 
 -- | Extract value from 'ServerKey'.
 getServerKey :: MonadIO m

--- a/src/Servant/Server/Experimental/Auth/Cookie.hs
+++ b/src/Servant/Server/Experimental/Auth/Cookie.hs
@@ -50,7 +50,10 @@ module Servant.Server.Experimental.Auth.Cookie
   , addSession
   , addSessionToErr
   , getSession
-
+  
+  -- exposed for testing purpose
+  , renderSession
+  
   , defaultAuthHandler
   ) where
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -7,24 +7,26 @@
 
 module Main (main) where
 
-import Control.Concurrent (threadDelay)
-import Crypto.Cipher.AES (AES256, AES192, AES128)
-import Crypto.Cipher.Types
-import Crypto.Hash (HashAlgorithm, SHA512, SHA384, SHA256)
-import Crypto.Random (drgNew)
-import Data.ByteString (ByteString)
-import Data.Default
-import Data.Proxy
-import Data.Serialize (Serialize)
-import Data.Time
-import GHC.Generics (Generic)
-import Servant.Server.Experimental.Auth.Cookie
-import Test.Hspec
-import Test.QuickCheck
-import qualified Data.ByteString as BS
+import           Control.Concurrent                      (threadDelay)
+import           Crypto.Cipher.AES                       (AES128, AES192,
+                                                          AES256)
+import           Crypto.Cipher.Types
+import           Crypto.Hash                             (HashAlgorithm, SHA256,
+                                                          SHA384, SHA512)
+import           Crypto.Random                           (drgNew)
+import           Data.ByteString                         (ByteString)
+import qualified Data.ByteString                         as BS
+import           Data.Default
+import           Data.Proxy
+import           Data.Serialize                          (Serialize)
+import           Data.Time
+import           GHC.Generics                            (Generic)
+import           Servant.Server.Experimental.Auth.Cookie
+import           Test.Hspec
+import           Test.QuickCheck
 
 #if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
+import           Control.Applicative
 #endif
 
 main :: IO ()
@@ -67,6 +69,12 @@ serverKeySpec = do
       sk <- mkServerKey keySize Nothing
       k  <- getServerKey sk
       BS.length k `shouldNotBe` (keySize `div` 8)
+  context "when creating a new server key from data" $
+    it "has data as server key" $ do
+      let bytes = "0123456789"
+      sk <- mkServerKeyFromBytes bytes
+      k  <- getServerKey sk
+      k `shouldBe` bytes
   context "until expiration" $
     it "returns the same key" $ do
       sk <- mkServerKey 16 Nothing


### PR DESCRIPTION
I am using this nice package to handle authentication across different services, each running in its own process behind a reverse proxy. I need a way to have a shared secret across all services requiring authentication hence this proposal to create a server key from some predefined bytes.