### PR TITLE
Added getHeaderSession to get session from servant header

### DIFF
--- a/servant-auth-cookie.cabal
+++ b/servant-auth-cookie.cabal
@@ -60,6 +60,7 @@ library
                , servant        >= 0.5   && < 0.12
                , servant-server >= 0.5   && < 0.12
                , tagged         == 0.8.*
+               , text
                , time           >= 1.5   && < 1.8.1
                , transformers   >= 0.4   && < 0.6
                , wai            >= 3.0   && < 3.3
@@ -144,6 +145,9 @@ executable example
       build-depends:
         servant >= 0.9,
         http-api-data == 0.3.*
+      other-modules:
+        AuthAPI
+        FileKeySet
     else
       build-depends:
         servant < 0.9,


### PR DESCRIPTION
I've updated the example to Fix #30 also added a `getHeaderSession` to the library and factored out shared code from `getSession`.

Let me know if there is anything you would like me to change or isn't happy with.