### PR TITLE
Allow cookie directives with two parts

### DIFF
--- a/example/AuthAPI.hs
+++ b/example/AuthAPI.hs
@@ -274,7 +274,7 @@ authHandler acs sks = mkAuthHandler $ \request ->
 -- production server, but is an obstacle if you want to check it without
 -- setting up TLS.
 authSettings :: AuthCookieSettings
-authSettings = def {acsCookieFlags = ["HttpOnly"]}
+authSettings = def {acsCookieFlags = [("HttpOnly","")]}
 
 -- | Application
 app :: (ServerKeySet s)

--- a/src/Servant/Server/Experimental/Auth/Cookie.hs
+++ b/src/Servant/Server/Experimental/Auth/Cookie.hs
@@ -476,7 +476,7 @@ data AuthCookieSettings where
   AuthCookieSettings :: (HashAlgorithm h, BlockCipher c) =>
     { acsSessionField :: ByteString
       -- ^ Name of a cookie which stores session object
-    , acsCookieFlags :: [ByteString]
+    , acsCookieFlags :: [(ByteString, ByteString)]
       -- ^ Session cookie's flags
     , acsMaxAge :: NominalDiffTime
       -- ^ For how long the cookie will be valid (corresponds to “Max-Age”
@@ -496,7 +496,7 @@ data AuthCookieSettings where
 instance Default AuthCookieSettings where
   def = AuthCookieSettings
     { acsSessionField = "Session"
-    , acsCookieFlags  = ["HttpOnly", "Secure"]
+    , acsCookieFlags  = [("HttpOnly",""), ("Secure","")]
     , acsMaxAge       = fromIntegral (12 * 3600 :: Integer) -- 12 hours
     , acsPath         = "/"
     , acsHashAlgorithm = Proxy :: Proxy SHA256
@@ -703,8 +703,7 @@ renderSession' AuthCookieSettings{..} (Tagged sessionBinary) expiration
   = toByteString . renderCookies
   $ (acsSessionField, sessionBinary)
   : ("Path", acsPath)
-  : ((maybe id (:) expiration)
-    $ ((,"") <$> acsCookieFlags))
+  : ((maybe id (:) expiration) acsCookieFlags)
 
 -- | Render session cookie to 'ByteString'.
 renderSession :: AddSession () ByteString


### PR DESCRIPTION
This is needed in order to set e.g. SameSite=Strict. It does make the default slightly uglier though.

I thought about splitting the field on '=', so "SameSite=Strict" would become ("SameSite,"Strict"), but I personally preferred this option. It does have the advantage of not breaking backward compatibility though.