### PR TITLE
Rewrite cookie generation to use Web.Cookie and generate spec conforming cookie headers

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.9
+resolver: lts-9.13
 packages:
 - '.'
 extra-deps:


### PR DESCRIPTION
Currently, servant-auth-cookie generates invalid cookies which fail on some browsers. The error is in the rendering of the previously available `acsCookieFlags` field. It resulted in cookies which look like
`name=value;HttpOnly=;Secure=;SameSite`. This failed to set a cookie for me on Chrome 64.0.3282.186 on OS X. Firefox and Safari seem to be more lenient in their cookie parsing and parsed the cookie successfully. In any case, if I read the [spec](https://tools.ietf.org/html/rfc6265#section-4.1.1) correctly, the above should be `name=value;HttpOnly;Secure;SameSite` (not the missing equals signs).

As this package already leverages Web.Cookie from the [cookie package](http://hackage.haskell.org/package/cookie-0.4.3/docs/Web-Cookie.html), I rewrote the rendering code to use the provided functions, which results in spec conforming cookies. This required the addition of specific fields for the `HttpOnly`, `Secure` and `SameSite` options in `AuthCookieSettings` type. I have added the fields in the default instance, so the tests continue to run. I am not sure what to do with the version number though - I will leave it up to you, as this *might* break user code if they were using the `acsCookieFlags` field.