### PR TITLE
Updating stack project to latest LTS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,7 @@ install:
  - cabal install -v --avoid-reinstalls servant-blaze hspec-wai --constraint='foundation < 0.0.5'
 
 script:
- - case "$CABALVER" in
-    "1.18") cabal configure --enable-tests --enable-library-coverage -v2 -f dev -f build-examples ;;
-    *)      cabal configure --enable-tests --enable-coverage -v2 -f dev -f build-examples ;;
-   esac
+ - cabal configure --enable-tests --enable-library-coverage -v2 -f dev -f build-examples
  - cabal build
  - cabal test --show-details=always
  - cabal sdist

--- a/servant-auth-cookie.cabal
+++ b/servant-auth-cookie.cabal
@@ -55,12 +55,12 @@ library
                , cookie         >= 0.4.1 && < 0.5
                , cryptonite     >= 0.14  && < 0.26
                , data-default
-               , exceptions     >= 0.8   && < 0.9
+               , exceptions     >= 0.8   && < 0.11
                , http-types     >= 0.9   && < 0.13
                , memory         >= 0.11  && < 0.15
                , mtl            >= 2.0   && < 3.0
-               , servant        >= 0.5   && < 0.14
-               , servant-server >= 0.5   && < 0.14
+               , servant        >= 0.5   && < 0.15
+               , servant-server >= 0.5   && < 0.15
                , tagged         == 0.8.*
                , text
                , time           >= 1.6   && < 1.8.1
@@ -109,7 +109,7 @@ test-suite tests
                , exceptions
                , hspec          >= 2.0  && < 3.0
                , servant-auth-cookie
-               , servant-server >= 0.5  && < 0.14
+               , servant-server >= 0.5  && < 0.15
                , tagged         == 0.8.*
                , template-haskell
                , transformers   >= 0.4  && < 0.6
@@ -137,10 +137,10 @@ executable example
                  , http-media
                  , http-types     >= 0.9  && < 0.13
                  , mtl            >= 2.0  && < 3.0
-                 , servant        >= 0.5  && < 0.14
+                 , servant        >= 0.5  && < 0.15
                  , servant-auth-cookie
                  , servant-blaze  >= 0.5  && < 0.8
-                 , servant-server >= 0.5  && < 0.14
+                 , servant-server >= 0.5  && < 0.15
                  , text
                  , time
                  , transformers   >= 0.4  && < 0.6
@@ -199,7 +199,7 @@ test-suite example-tests
                  , QuickCheck     >= 2.4  && < 3.0
                  , servant-auth-cookie
                  , servant-blaze  >= 0.5  && < 0.8
-                 , servant-server >= 0.5  && < 0.14
+                 , servant-server >= 0.5  && < 0.15
                  , text
                  , time           >= 1.5  && < 1.8.1
                  , transformers   >= 0.4  && < 0.6
@@ -240,7 +240,7 @@ benchmark bench
                , criterion      >= 0.6.2.1 && < 1.4
                , cryptonite     >= 0.14    && < 0.26
                , servant-auth-cookie
-               , servant-server >= 0.5     && < 0.13
+               , servant-server >= 0.5     && < 0.15
   if flag(dev)
     ghc-options:      -Wall -Werror
   else

--- a/servant-auth-cookie.cabal
+++ b/servant-auth-cookie.cabal
@@ -47,19 +47,19 @@ library
 
   build-depends: base           >= 4.7   && < 5.0
                , base64-bytestring
-               , blaze-builder  >= 0.4   && < 0.4.1
+               , blaze-builder  >= 0.4   && < 0.4.2
                , bytestring
                , cereal         >= 0.5   && < 0.6
                , cereal-time    >= 0.1   && < 0.2
                , cookie         >= 0.4.1 && < 0.5
-               , cryptonite     >= 0.14  && < 0.25
+               , cryptonite     >= 0.14  && < 0.26
                , data-default
                , exceptions     >= 0.8   && < 0.9
-               , http-types     >= 0.9   && < 0.12
+               , http-types     >= 0.9   && < 0.13
                , memory         >= 0.11  && < 0.15
                , mtl            >= 2.0   && < 3.0
-               , servant        >= 0.5   && < 0.13
-               , servant-server >= 0.5   && < 0.13
+               , servant        >= 0.5   && < 0.14
+               , servant-server >= 0.5   && < 0.14
                , tagged         == 0.8.*
                , text
                , time           >= 1.6   && < 1.8.1
@@ -102,13 +102,13 @@ test-suite tests
                , QuickCheck     >= 2.4  && < 3.0
                , bytestring
                , cereal         >= 0.5  && < 0.6
-               , cryptonite     >= 0.14 && < 0.25
+               , cryptonite     >= 0.14 && < 0.26
                , data-default
                , deepseq        >= 1.3  && < 1.5
                , exceptions
                , hspec          >= 2.0  && < 3.0
                , servant-auth-cookie
-               , servant-server >= 0.5  && < 0.13
+               , servant-server >= 0.5  && < 0.14
                , tagged         == 0.8.*
                , template-haskell
                , transformers   >= 0.4  && < 0.6
@@ -128,7 +128,7 @@ executable example
                  , blaze-markup   >= 0.7  && < 0.9
                  , bytestring
                  , cereal         >= 0.5  && < 0.6
-                 , cryptonite     >= 0.14 && < 0.25
+                 , cryptonite     >= 0.14 && < 0.26
                  , data-default
                  , directory
                  , exceptions
@@ -136,10 +136,10 @@ executable example
                  , http-media
                  , http-types     >= 0.9  && < 0.12
                  , mtl            >= 2.0  && < 3.0
-                 , servant        >= 0.5  && < 0.13
+                 , servant        >= 0.5  && < 0.14
                  , servant-auth-cookie
                  , servant-blaze  >= 0.5  && < 0.8
-                 , servant-server >= 0.5  && < 0.13
+                 , servant-server >= 0.5  && < 0.14
                  , text
                  , time
                  , transformers   >= 0.4  && < 0.6
@@ -185,7 +185,7 @@ test-suite example-tests
                  , cereal         >= 0.5  && < 0.6
                  , cookie
                  , exceptions
-                 , cryptonite     >= 0.14 && < 0.25
+                 , cryptonite     >= 0.14 && < 0.26
                  , data-default
                  , deepseq        >= 1.3  && < 1.5
                  , directory
@@ -198,7 +198,7 @@ test-suite example-tests
                  , QuickCheck     >= 2.4  && < 3.0
                  , servant-auth-cookie
                  , servant-blaze  >= 0.5  && < 0.8
-                 , servant-server >= 0.5  && < 0.13
+                 , servant-server >= 0.5  && < 0.14
                  , text
                  , time           >= 1.5  && < 1.8.1
                  , transformers   >= 0.4  && < 0.6
@@ -237,7 +237,7 @@ benchmark bench
   build-depends: base           >= 4.7     && < 5.0
                , bytestring
                , criterion      >= 0.6.2.1 && < 1.4
-               , cryptonite     >= 0.14    && < 0.25
+               , cryptonite     >= 0.14    && < 0.26
                , servant-auth-cookie
                , servant-server >= 0.5     && < 0.13
   if flag(dev)

--- a/servant-auth-cookie.cabal
+++ b/servant-auth-cookie.cabal
@@ -59,8 +59,8 @@ library
                , http-types     >= 0.9   && < 0.13
                , memory         >= 0.11  && < 0.15
                , mtl            >= 2.0   && < 3.0
-               , servant        >= 0.5   && < 0.15
-               , servant-server >= 0.5   && < 0.15
+               , servant        >= 0.5   && < 0.16
+               , servant-server >= 0.5   && < 0.16
                , tagged         == 0.8.*
                , text
                , time           >= 1.6   && < 1.8.1
@@ -77,12 +77,12 @@ library
   if flag(servant9)
     build-depends:
       servant >= 0.9,
-      http-api-data == 0.3.*
+      http-api-data == 0.4.*
   else
     if flag(servant91)
       build-depends:
         servant >= 0.9,
-        http-api-data == 0.3.*
+        http-api-data == 0.4.*
     else
       build-depends:
         servant < 0.9,
@@ -109,7 +109,7 @@ test-suite tests
                , exceptions
                , hspec          >= 2.0  && < 3.0
                , servant-auth-cookie
-               , servant-server >= 0.5  && < 0.15
+               , servant-server >= 0.5  && < 0.16
                , tagged         == 0.8.*
                , template-haskell
                , transformers   >= 0.4  && < 0.6
@@ -137,10 +137,10 @@ executable example
                  , http-media
                  , http-types     >= 0.9  && < 0.13
                  , mtl            >= 2.0  && < 3.0
-                 , servant        >= 0.5  && < 0.15
+                 , servant        >= 0.5  && < 0.16
                  , servant-auth-cookie
                  , servant-blaze  >= 0.5  && < 0.8
-                 , servant-server >= 0.5  && < 0.15
+                 , servant-server >= 0.5  && < 0.16
                  , text
                  , time
                  , transformers   >= 0.4  && < 0.6
@@ -149,7 +149,7 @@ executable example
     if flag(servant9)
       build-depends:
         servant >= 0.9,
-        http-api-data == 0.3.*
+        http-api-data == 0.4.*
       other-modules:
         AuthAPI
         FileKeySet
@@ -199,7 +199,7 @@ test-suite example-tests
                  , QuickCheck     >= 2.4  && < 3.0
                  , servant-auth-cookie
                  , servant-blaze  >= 0.5  && < 0.8
-                 , servant-server >= 0.5  && < 0.15
+                 , servant-server >= 0.5  && < 0.16
                  , text
                  , time           >= 1.5  && < 1.8.1
                  , transformers   >= 0.4  && < 0.6
@@ -208,12 +208,12 @@ test-suite example-tests
     if flag(servant9)
       build-depends:
         servant >= 0.9,
-        http-api-data == 0.3.*
+        http-api-data == 0.4.*
     else
       if flag(servant91)
         build-depends:
           servant >= 0.9.1,
-          http-api-data == 0.3.*
+          http-api-data == 0.4.*
       else
         build-depends:
           servant < 0.9,
@@ -240,7 +240,7 @@ benchmark bench
                , criterion      >= 0.6.2.1 && < 1.4
                , cryptonite     >= 0.14    && < 0.26
                , servant-auth-cookie
-               , servant-server >= 0.5     && < 0.15
+               , servant-server >= 0.5     && < 0.16
   if flag(dev)
     ghc-options:      -Wall -Werror
   else

--- a/servant-auth-cookie.cabal
+++ b/servant-auth-cookie.cabal
@@ -1,3 +1,4 @@
+
 name:                servant-auth-cookie
 version:             0.6.0.3
 synopsis:            Authentication via encrypted cookies
@@ -134,7 +135,7 @@ executable example
                  , exceptions
                  , filepath
                  , http-media
-                 , http-types     >= 0.9  && < 0.12
+                 , http-types     >= 0.9  && < 0.13
                  , mtl            >= 2.0  && < 3.0
                  , servant        >= 0.5  && < 0.14
                  , servant-auth-cookie
@@ -191,7 +192,7 @@ test-suite example-tests
                  , directory
                  , filepath
                  , http-media
-                 , http-types     >= 0.9  && < 0.12
+                 , http-types     >= 0.9  && < 0.13
                  , hspec          >= 2.0  && < 3.0
                  , hspec-wai
                  , mtl            >= 2.0  && < 3.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-12.0
+resolver: lts-13.5
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,3 @@
-resolver: lts-8.9
+resolver: lts-11.1
 packages:
 - '.'
-extra-deps:
-  - cereal-time-0.1.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-11.1
+resolver: lts-12.0
 packages:
 - '.'


### PR DESCRIPTION
I'd like to migrate a project that depends on servant-auth-cookie to servant 0.13.  